### PR TITLE
Feat/profile page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Login from './Pages/Login/Login';
 import Landing from './Pages/Landing/Landing';
-import Profile from './Pages/Profile';
+import Profile from './Pages/Profile/Profile';
 
 const theme = createTheme({
   palette: {

--- a/frontend/src/Pages/Landing/Forms/CitySearchForm.tsx
+++ b/frontend/src/Pages/Landing/Forms/CitySearchForm.tsx
@@ -17,7 +17,6 @@ const CitySearchForm = ({ city, setCity, setSubmitted }: Props) => {
         <Box
             component="form"
             sx={{
-                outline: '1px solid red',
                 marginY: '2rem',
                 width: '100%',
                 display: 'flex',

--- a/frontend/src/Pages/Landing/Forms/FilterForm.tsx
+++ b/frontend/src/Pages/Landing/Forms/FilterForm.tsx
@@ -41,7 +41,6 @@ const FilterForm = ({ submitted, city }: Props) => {
             width: '30%',
             display: 'flex',
             flexDirection: 'column',
-            outline: '1px solid black',
             padding: '1rem'
         }}>
             <TypeCheckboxes

--- a/frontend/src/Pages/Landing/Landing.tsx
+++ b/frontend/src/Pages/Landing/Landing.tsx
@@ -13,7 +13,6 @@ const Landing = () => {
             display: 'flex',
             flexDirection: 'column',
             width: "100%",
-            outline: '1px solid blue'
         }}>
             <CitySearchForm
                 city={city}

--- a/frontend/src/Pages/Login/Form.tsx
+++ b/frontend/src/Pages/Login/Form.tsx
@@ -109,10 +109,11 @@ const Form: React.FC = () => {
 
     <Formik onSubmit={handleFormSubmit}
       initialValues={isLogin ? intialValuesLogin : intialValuesRegister}
-      validationSchema={isLogin ? loginSchema : registerSchema}>
+      validationSchema={isLogin ? loginSchema : registerSchema}
+    >
       {({ values, errors, touched, handleBlur, handleChange, handleSubmit, setFieldValue, resetForm }) => (
         <form onSubmit={handleSubmit}>
-          <Box display="grid" gap="30px" gridTemplateColumns="repeat(4, minmax(0, 1fr))"
+          <Box display="grid" gap="2rem" gridTemplateColumns="repeat(4, minmax(0, 1fr))"
             sx={{
               "&>div": {
                 gridColumn: isNonMobileScreens ? undefined : "span 4"
@@ -121,10 +122,8 @@ const Form: React.FC = () => {
             }
           >
 
-
             {isRegister && (
               <>
-
                 <TextField
                   label="User Name"
                   onBlur={handleBlur}
@@ -138,10 +137,6 @@ const Form: React.FC = () => {
                     gridColumn: "span 4",
                     borderRadius: "5px",
                     mt: "0.2rem"
-
-
-
-
                   }}
                 />
 
@@ -224,13 +219,9 @@ const Form: React.FC = () => {
                           </Box>
                         )}
                       </Box>
-
                     )}
                   </Dropzone>
-
                 </Box>
-
-
               </>
             )}
 

--- a/frontend/src/Pages/Login/Login.tsx
+++ b/frontend/src/Pages/Login/Login.tsx
@@ -3,39 +3,36 @@ import {
   Box, useMediaQuery
 } from '@mui/material';
 import Form from './Form';
-import { useTheme, IconButton } from '@mui/material';
-import Brightness4Icon from '@mui/icons-material/Brightness4';
-import Brightness7Icon from '@mui/icons-material/Brightness7';
-
 
 const Login = () => {
-  const theme = useTheme();
-  const toggleThemeMode = () => {
-    const newMode = theme.palette.mode === 'light' ? 'dark' : 'light';
-    theme.palette.mode = newMode;
-  };
 
   const isNonMobileScreens = useMediaQuery(("(min-width:1000px"));
   return (
-    <>
-      <IconButton onClick={toggleThemeMode} aria-label="Toggle theme mode">
-        {theme.palette.mode === 'light' ? <Brightness4Icon /> : <Brightness7Icon />}
-      </IconButton>
-
-      <Box width="100%" padding="0.4rem 2%" textAlign="center"  >
-        <Typography fontWeight="bold" fontSize="32px" color="#330066" >Sight.See.Share</Typography>
-        <Box width={isNonMobileScreens ? "95%" : "77%"} p="2rem" m="2rem auto"
+    <Box
+      component="section"
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        placeItems: 'center',
+        paddingTop: '1rem'
+      }}
+    >
+      <Box
+        width={isNonMobileScreens ? "70%" : "95%"}
+        textAlign="center"  >
+        <Typography fontWeight="bold" fontSize="2rem" color="#330066" >Log In or Register</Typography>
+        <Box
+          width={isNonMobileScreens ? "95%" : "77%"}
+          p="2rem"
+          m="1rem auto"
           borderRadius="1.5rem"
           border="2px solid"
           borderColor="#b3b3ff"
-
-
         >
-
           <Form />
         </Box>
       </Box>
-    </>
+    </Box>
 
 
   );

--- a/frontend/src/Pages/Profile.tsx
+++ b/frontend/src/Pages/Profile.tsx
@@ -1,8 +1,0 @@
-
-const Profile = () => {
-    return (
-        <div>Profile Page</div>
-    )
-}
-
-export default Profile

--- a/frontend/src/Pages/Profile/Profile.tsx
+++ b/frontend/src/Pages/Profile/Profile.tsx
@@ -1,5 +1,9 @@
-import { Avatar, Box, List, ListItem, ListItemText } from "@mui/material"
+import { Avatar, Box, List, ListItem, ListItemText, useTheme, IconButton } from "@mui/material"
 import { useState } from "react"
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+import Brightness7Icon from '@mui/icons-material/Brightness7';
+
+
 
 const Profile = () => {
     // Test user data to be removed once this is connected to the back end
@@ -12,6 +16,12 @@ const Profile = () => {
         location: 'Toronto',
         profile_image: '/static/images/avatar/1.jpg'
     })
+
+    const theme = useTheme();
+    const toggleThemeMode = () => {
+        const newMode = theme.palette.mode === 'light' ? 'dark' : 'light';
+        theme.palette.mode = newMode;
+    };
 
     const { first_name, last_name, user_name, occupation, email, location, profile_image } = user;
 
@@ -28,8 +38,11 @@ const Profile = () => {
                 <Avatar
                     alt={`${first_name} ${last_name} `}
                     src={profile_image}
-                    sx={{ width: 100, height: 100 }}
+                    sx={{ width: 100, height: 100, marginBottom: '1rem' }}
                 />
+                <IconButton onClick={toggleThemeMode} aria-label="Toggle theme mode">
+                    {theme.palette.mode === 'light' ? <Brightness4Icon /> : <Brightness7Icon />}
+                </IconButton>
             </Box>
             <Box>
                 <List >

--- a/frontend/src/Pages/Profile/Profile.tsx
+++ b/frontend/src/Pages/Profile/Profile.tsx
@@ -1,0 +1,78 @@
+import { Avatar, Box, List, ListItem, ListItemText } from "@mui/material"
+import { useState } from "react"
+
+const Profile = () => {
+    // Test user data to be removed once this is connected to the back end
+    const [user, setUser] = useState({
+        first_name: 'Daniela',
+        last_name: 'Parra',
+        user_name: 'phycodurus',
+        occupation: 'Software Engineer',
+        email: 'myemail@gmail.com',
+        location: 'Toronto',
+        profile_image: '/static/images/avatar/1.jpg'
+    })
+
+    const { first_name, last_name, user_name, occupation, email, location, profile_image } = user;
+
+    return (
+        <Box
+            component="section"
+            sx={{
+                display: 'flex',
+                placeContent: 'center',
+                gap: '5rem'
+            }}
+        >
+            <Box>
+                <Avatar
+                    alt={`${first_name} ${last_name} `}
+                    src={profile_image}
+                    sx={{ width: 100, height: 100 }}
+                />
+            </Box>
+            <Box>
+                <List >
+                    <ListItem>
+                        <ListItemText
+                            primary={user_name}
+                            secondary="Username"
+                        />
+                    </ListItem>
+                    <ListItem>
+                        <ListItemText
+                            primary={first_name}
+                            secondary="First Name"
+                        />
+                    </ListItem>
+                    <ListItem>
+                        <ListItemText
+                            primary={last_name}
+                            secondary="Last Name"
+                        />
+                    </ListItem>
+                    <ListItem>
+                        <ListItemText
+                            primary={email}
+                            secondary="Email Address"
+                        />
+                    </ListItem>
+                    <ListItem>
+                        <ListItemText
+                            primary={location}
+                            secondary="Location"
+                        />
+                    </ListItem>
+                    <ListItem>
+                        <ListItemText
+                            primary={occupation}
+                            secondary="Occupation"
+                        />
+                    </ListItem>
+                </List>
+            </Box>
+        </Box>
+    )
+}
+
+export default Profile


### PR DESCRIPTION
Updated Profile page
- Static page that now contains MUI elements to display data. Currently just using a hardcoded user's information until we can get it connected to back end
- Darkmode toggle button is now in Profile page instead of Login page 

Minor tweaks to Login page
- Fixed component width back to Mays's original design 
- Darkmode toggle removed from this page
- Changed 'Sight.See.Share' headline to 'Login or Register' as the app name is now on the Nav and doesn't need to appear twice

Removed colour outlines from Landing page since they are no longer needed