### PR TITLE
Fixing or bypassing TS errors temporarily for deployment

### DIFF
--- a/frontend/src/Pages/Landing/Forms/FilterForm.tsx
+++ b/frontend/src/Pages/Landing/Forms/FilterForm.tsx
@@ -31,7 +31,9 @@ const FilterForm = ({ submitted, city }: Props) => {
         });
     };
 
-    const handleSliderChange = (event: Event, newValue: number | number[]) => {
+    // Note event param is currently not being used, but is required for this function to update the slider correctly. 
+    // Added _ prefix to remove TS error about unused variables
+    const handleSliderChange = (_event: Event, newValue: number | number[]) => {
         setSliderValue(newValue as number);
     };
 

--- a/frontend/src/Pages/Profile/Profile.tsx
+++ b/frontend/src/Pages/Profile/Profile.tsx
@@ -1,5 +1,4 @@
 import { Avatar, Box, List, ListItem, ListItemText, useTheme, IconButton } from "@mui/material"
-import { useState } from "react"
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 
@@ -7,7 +6,8 @@ import Brightness7Icon from '@mui/icons-material/Brightness7';
 
 const Profile = () => {
     // Test user data to be removed once this is connected to the back end
-    const [user, setUser] = useState({
+
+    const user = {
         first_name: 'Daniela',
         last_name: 'Parra',
         user_name: 'phycodurus',
@@ -15,7 +15,7 @@ const Profile = () => {
         email: 'myemail@gmail.com',
         location: 'Toronto',
         profile_image: '/static/images/avatar/1.jpg'
-    })
+    }
 
     const theme = useTheme();
     const toggleThemeMode = () => {


### PR DESCRIPTION
Fixed two TS errors that came up while trying to deploy:

In the FilterForm.tsx component
- ERROR: The handleSliderChange function definition requires an event parameter in order to pass values correctly, however the event param itself is not actually used. 
- TS was throwing an error for a variable being declared but not used
- SOLUTION: added a "_" prefix to the event param, which signals that a variable is intentionally left unused and removes the error

In the Profile.tsx component
- ERROR: the 'user' state declaration was throwing an error because setUser was declared but not used 
- Same TS error as above
- SOLUTION: instead of using a stateful variable, I changed it to a regular variable. This removes the error as the setUser function is no longer defined. 

Please let me know if you are OK with these solutions (the one for Profile.tsx is likely temporary anyway).
