### PR TITLE
Mobile interface props updates

### DIFF
--- a/frontend/src/Pages/Landing/Forms/CitySearchForm.tsx
+++ b/frontend/src/Pages/Landing/Forms/CitySearchForm.tsx
@@ -1,16 +1,15 @@
 import { Box, Button, TextField } from "@mui/material";
-import React from "react";
+import React, { useState } from "react";
 const MAPBOX_ACCESS_TOKEN = import.meta.env.VITE_MAPBOX_TOKEN;
 
 type Props = {
-    city: string,
-    setCity: React.Dispatch<React.SetStateAction<string>>,
     setSubmitted: React.Dispatch<React.SetStateAction<boolean>>,
     setLongitude: React.Dispatch<React.SetStateAction<number>>,
     setLatitude: React.Dispatch<React.SetStateAction<number>>
 }
 
-const CitySearchForm = ({ city, setCity, setSubmitted, setLongitude, setLatitude }: Props) => {
+const CitySearchForm = ({ setSubmitted, setLongitude, setLatitude }: Props) => {
+    const [city, setCity] = useState('');
     const encodedCity = encodeURI(city) || "";
     const mapboxQuery = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodedCity}.json?access_token=${MAPBOX_ACCESS_TOKEN}`
 

--- a/frontend/src/Pages/Landing/Forms/FilterForm.tsx
+++ b/frontend/src/Pages/Landing/Forms/FilterForm.tsx
@@ -4,7 +4,7 @@ import { Box } from '@mui/material';
 import TypeCheckboxes from './Components/TypeCheckboxes';
 import RatingCheckboxes from './Components/RatingCheckboxes';
 import PriceSlider from './Components/PriceSlider';
-import { IPointsOfInterest } from '../Landing';
+import { IPointsOfInterest } from '../../../types/interfaces';
 
 // NOTE: city prop is currently only needed for the StateChecker component - it can be removed once we no longer need to use that component
 

--- a/frontend/src/Pages/Landing/Landing.tsx
+++ b/frontend/src/Pages/Landing/Landing.tsx
@@ -1,25 +1,9 @@
 import { Box } from "@mui/material"
 import { useState, useEffect } from 'react';
-
 import CitySearchForm from './Forms/CitySearchForm';
 import FilterForm from './Forms/FilterForm';
 import MapContainer from "./MapContainer";
-
-export interface IPointsOfInterest {
-    title: string;
-    category: string;
-    description: string;
-    longitude: number;
-    latitude: number;
-    price: string;
-    city: string;
-    website: string;
-    post_code: string;
-    province: string;
-    country: string;
-    phone_number: number;
-    userId: number;
-}
+import { IPointsOfInterest } from "../../types/interfaces";
 
 const Landing = () => {
     // We might be able to move the city/setCity declaration into the CitySearchForm once we no longer use the StateChecker component in FilterForm, as that is the only other component that requires the city state

--- a/frontend/src/Pages/Landing/Landing.tsx
+++ b/frontend/src/Pages/Landing/Landing.tsx
@@ -6,8 +6,6 @@ import MapContainer from "./MapContainer";
 import { IPointsOfInterest } from "../../types/interfaces";
 
 const Landing = () => {
-    // We might be able to move the city/setCity declaration into the CitySearchForm once we no longer use the StateChecker component in FilterForm, as that is the only other component that requires the city state
-    const [city, setCity] = useState('');
     const [submitted, setSubmitted] = useState(false);
     const [longitude, setLongitude] = useState(-74.0060);
     const [latitude, setLatitude] = useState(40.7128);
@@ -33,8 +31,6 @@ const Landing = () => {
             width: "100%",
         }}>
             <CitySearchForm
-                city={city}
-                setCity={setCity}
                 setSubmitted={setSubmitted}
                 setLongitude={setLongitude}
                 setLatitude={setLatitude}

--- a/frontend/src/Pages/Landing/MapContainer.tsx
+++ b/frontend/src/Pages/Landing/MapContainer.tsx
@@ -1,10 +1,10 @@
 import { useRef, useEffect, useState } from 'react';
 import mapboxgl from 'mapbox-gl';
 import { Box } from '@mui/material';
+import { IPointsOfInterest } from '../../types/interfaces';
 mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_TOKEN;
 type MarkerWithId = mapboxgl.Marker & { id: string };
 type PopupWithId = mapboxgl.Popup & { id: string };
-import { IPointsOfInterest } from './Landing';
 
 type Props = {
     longitude: number;
@@ -35,7 +35,7 @@ const MapComponent = ({ longitude, latitude, renderedPointsOfInterest }: Props) 
             const marker = new mapboxgl.Marker() as MarkerWithId;
             marker.setLngLat([poi.longitude, poi.latitude]);
             marker.addTo(map.current);
-        };
+        }
 
     }, [longitude, latitude, renderedPointsOfInterest])
 

--- a/frontend/src/Pages/Login/Form.tsx
+++ b/frontend/src/Pages/Login/Form.tsx
@@ -12,21 +12,10 @@ import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
 import Dropzone from "react-dropzone";
 import * as yup from "yup";
 import axiosInstance from "../../axiosConfig";
+import { LoginFormValues } from "../../types/interfaces";
 import.meta.env.VITE_APP_CLOUD_NAME;
 
-interface FormValues {
-  first_name?: string;
-  last_name?: string;
-  user_name?: string;
-  occupation?: string;
-  email: string;
-  password: string;
-
-  location?: string;
-  profile_image?: File | null;
-}
-
-const intialValuesRegister: FormValues = {
+const intialValuesRegister: LoginFormValues = {
   first_name: "",
   last_name: "",
   user_name: "",
@@ -37,7 +26,7 @@ const intialValuesRegister: FormValues = {
   location: "",
   profile_image: null,
 };
-const intialValuesLogin: FormValues = {
+const intialValuesLogin: LoginFormValues = {
   email: "",
   password: "",
 };
@@ -60,8 +49,8 @@ const Form: React.FC = () => {
   const navigate = useNavigate();
 
   const handleLogin = async (
-    values: FormValues,
-    onSubmitProps: FormikHelpers<FormValues>
+    values: LoginFormValues,
+    onSubmitProps: FormikHelpers<LoginFormValues>
   ) => {
     try {
       const loginResponse = await axiosInstance.post(
@@ -83,15 +72,15 @@ const Form: React.FC = () => {
   };
 
   const handleRegister = async (
-    values: FormValues,
-    onSubmitProps: FormikHelpers<FormValues>
+    values: LoginFormValues,
+    onSubmitProps: FormikHelpers<LoginFormValues>
   ) => {
     let imageUrl;
     try {
       const formData = new FormData();
 
       for (const key in values) {
-        const value = values[key as keyof FormValues];
+        const value = values[key as keyof LoginFormValues];
 
         if (key === "profile_image" && value instanceof File) {
           formData.append("file", value);
@@ -105,8 +94,7 @@ const Form: React.FC = () => {
           );
 
           const cloudinaryResponse = await fetch(
-            `https://api.cloudinary.com/v1_1/${
-              import.meta.env.VITE_APP_CLOUD_NAME
+            `https://api.cloudinary.com/v1_1/${import.meta.env.VITE_APP_CLOUD_NAME
             }/image/upload`,
             {
               method: "POST",
@@ -154,8 +142,8 @@ const Form: React.FC = () => {
     }
   };
   const handleFormSubmit = async (
-    values: FormValues,
-    onSubmitProps: FormikHelpers<FormValues>
+    values: LoginFormValues,
+    onSubmitProps: FormikHelpers<LoginFormValues>
   ) => {
     if (isLogin) return await handleLogin(values, onSubmitProps);
     if (isRegister) return await handleRegister(values, onSubmitProps);

--- a/frontend/src/Pages/POI/PointOfIntrest.tsx
+++ b/frontend/src/Pages/POI/PointOfIntrest.tsx
@@ -1,35 +1,26 @@
-import { Typography,
-  Box , useMediaQuery} from '@mui/material';
+import {
+  Typography,
+  Box, useMediaQuery
+} from '@mui/material';
 import PostForm from './PostForm';
 
-
-
-
 const PointOfIntrest = () => {
-  
 
   const isNonMobileScreens = useMediaQuery(("(min-width:1000px"));
- 
+
   return (
     <>
-
-   
-    <Box width="100%" padding="0.4rem 2%" textAlign="center"  >
-    <Typography fontWeight="bold" fontSize="32px" color="#330066" >Create a Post</Typography>
-    <Box width={isNonMobileScreens? "55%": "77%"} p="2rem" m="2rem auto"
-  borderRadius="1.5rem"
-  border="2px solid"
-  borderColor="#b3b3ff"
-  
-  
-  >
-
-  <PostForm/>
-  </Box>
-  </Box>
-  </>
-   
-  
+      <Box width="100%" padding="0.4rem 2%" textAlign="center"  >
+        <Typography fontWeight="bold" fontSize="32px" color="#330066" >Create a Post</Typography>
+        <Box width={isNonMobileScreens ? "55%" : "77%"} p="2rem" m="2rem auto"
+          borderRadius="1.5rem"
+          border="2px solid"
+          borderColor="#b3b3ff"
+        >
+          <PostForm />
+        </Box>
+      </Box>
+    </>
   );
 }
 

--- a/frontend/src/Pages/POI/PostForm.tsx
+++ b/frontend/src/Pages/POI/PostForm.tsx
@@ -15,28 +15,9 @@ const MAPBOX_ACCESS_TOKEN = import.meta.env.VITE_MAPBOX_TOKEN;
 
 import * as yup from 'yup';
 import { Field, Formik, FormikHelpers, FieldProps } from 'formik';
+import { PoIFormValues } from '../../types/interfaces';
 
-interface FormValues {
-  title: string;
-  category: string;
-  description: string;
-  price?: number;
-  website?: string;
-  city?: string;
-  post_code?: string;
-  province: string;
-  country?: string;
-  phoneNumber?: string;
-  address?: string;
-  selectedOption: string;
-  longitude?: number;
-  latitude?: number;
-  userId:string
-}
-
-
-
-const formData: FormValues = {
+const formData: PoIFormValues = {
   title: '',
   category: '',
   description: '',
@@ -44,14 +25,14 @@ const formData: FormValues = {
   website: '',
   city: '',
   post_code: '',
-  province: '', 
+  province: '',
   country: '',
   phoneNumber: '',
   address: '',
   selectedOption: '',
   longitude: 0,
   latitude: 0,
-  userId:""
+  userId: ""
 };
 
 const formSchema = yup.object().shape({
@@ -63,7 +44,7 @@ const formSchema = yup.object().shape({
 const PostForm = () => {
   const isNonMobileScreens = useMediaQuery('(min-width: 600px)');
   const navigate = useNavigate();
- 
+
 
   const geocodeAddress = async (address: string) => {
     try {
@@ -87,29 +68,29 @@ const PostForm = () => {
       throw error;
     }
   };
-  
+
   const handleFormSubmit = async (
-    values: FormValues,
-    onSubmitProps: FormikHelpers<FormValues>
-    ) => {
-      
-      try {
-        values.category = values.selectedOption;
-        const userId = sessionStorage.getItem('userId');
-        if (!userId || typeof userId !== 'string') {
-          console.error('Invalid userId:', userId);
-          return; 
-        }
-        
-        values.userId = userId;
-        
-        if (values.address) {
-          
-          const geocodeResult = await geocodeAddress(values.address);
-          values.longitude = geocodeResult.longitude;
-          values.latitude = geocodeResult.latitude;
-        }
-        
+    values: PoIFormValues,
+    onSubmitProps: FormikHelpers<PoIFormValues>
+  ) => {
+
+    try {
+      values.category = values.selectedOption;
+      const userId = sessionStorage.getItem('userId');
+      if (!userId || typeof userId !== 'string') {
+        console.error('Invalid userId:', userId);
+        return;
+      }
+
+      values.userId = userId;
+
+      if (values.address) {
+
+        const geocodeResult = await geocodeAddress(values.address);
+        values.longitude = geocodeResult.longitude;
+        values.latitude = geocodeResult.latitude;
+      }
+
       const saveResponseData = await fetch('http://localhost:3000/pointOfInterest', {
         method: 'POST',
         body: JSON.stringify(values),
@@ -119,19 +100,19 @@ const PostForm = () => {
       });
 
       if (!saveResponseData.ok) {
-     
+
         throw new Error(`Failed to save data: ${saveResponseData.status}`);
       }
 
       const savedUser = await saveResponseData.json();
-      
+
       onSubmitProps.resetForm();
       if (savedUser) {
         navigate('/');
       }
     } catch (error) {
       console.error('Error:', error);
-     
+
     }
   };
 
@@ -187,8 +168,8 @@ const PostForm = () => {
                   sx={{
                     gridColumn: 'span 2',
                     borderRadius: '5px',
-                    p:'6px'
-                    
+                    p: '6px'
+
                   }}
                   error={touched.selectedOption && Boolean(errors.selectedOption)}
                 >
@@ -218,10 +199,10 @@ const PostForm = () => {
               sx={{
                 gridColumn: 'span 2',
                 borderRadius: '5px',
-                p:'6px'
+                p: '6px'
               }}
             />
-         
+
             <TextField
               label="Address"
               onBlur={handleBlur}
@@ -299,7 +280,7 @@ const PostForm = () => {
                 mt: '0.2rem',
               }}
             />
-               <TextField
+            <TextField
               label="Website"
               onBlur={handleBlur}
               onChange={handleChange}

--- a/frontend/src/Pages/Profile/Profile.tsx
+++ b/frontend/src/Pages/Profile/Profile.tsx
@@ -11,16 +11,7 @@ import Brightness4Icon from "@mui/icons-material/Brightness4";
 import Brightness7Icon from "@mui/icons-material/Brightness7";
 import { useEffect, useState } from "react";
 import axiosInstance from "../../axiosConfig";
-
-interface UserData {
-  user_name: string;
-  profile_image?: string;
-  first_name: string;
-  last_name: string;
-  occupation: string;
-  email: string;
-  location: string;
-}
+import { UserData } from "../../types/interfaces";
 
 const Profile = () => {
 

--- a/frontend/src/Pages/Profile/Profile.tsx
+++ b/frontend/src/Pages/Profile/Profile.tsx
@@ -23,6 +23,7 @@ interface UserData {
 }
 
 const Profile = () => {
+
   const [userData, setUserData] = useState<UserData | null>(null);
 
   const fetchUserProfile = async (userId: string) => {
@@ -58,8 +59,16 @@ const Profile = () => {
       component="section"
       sx={{
         display: "flex",
-        placeContent: "center",
-        gap: "5rem",
+        flexDirection: {
+          xs: "column",
+          sm: "row"
+        },
+        justifyContent: "center",
+        alignItems: "center",
+        gap: {
+          xs: "1rem",
+          sm: "5rem"
+        }
       }}
     >
       {/* Check if userData exists before rendering */}
@@ -84,40 +93,46 @@ const Profile = () => {
           </Box>
           <Box>
             <List>
-              <ListItem>
+              <ListItem >
                 <ListItemText
                   primary={userData.user_name}
                   secondary="Username"
+                  sx={{ textAlign: { xs: "center", sm: "left" } }}
                 />
               </ListItem>
               <ListItem>
                 <ListItemText
                   primary={userData.first_name}
                   secondary="First Name"
+                  sx={{ textAlign: { xs: "center", sm: "left" } }}
                 />
               </ListItem>
               <ListItem>
                 <ListItemText
                   primary={userData.last_name}
                   secondary="Last Name"
+                  sx={{ textAlign: { xs: "center", sm: "left" } }}
                 />
               </ListItem>
               <ListItem>
                 <ListItemText
                   primary={userData.email}
                   secondary="Email Address"
+                  sx={{ textAlign: { xs: "center", sm: "left" } }}
                 />
               </ListItem>
               <ListItem>
                 <ListItemText
                   primary={userData.location}
                   secondary="Location"
+                  sx={{ textAlign: { xs: "center", sm: "left" } }}
                 />
               </ListItem>
               <ListItem>
                 <ListItemText
                   primary={userData.occupation}
                   secondary="Occupation"
+                  sx={{ textAlign: { xs: "center", sm: "left" } }}
                 />
               </ListItem>
             </List>

--- a/frontend/src/types/interfaces.ts
+++ b/frontend/src/types/interfaces.ts
@@ -1,0 +1,54 @@
+export interface IPointsOfInterest {
+	title: string;
+	category: string;
+	description: string;
+	longitude: number;
+	latitude: number;
+	price: string;
+	city: string;
+	website: string;
+	post_code: string;
+	province: string;
+	country: string;
+	phone_number: number;
+	userId: number;
+}
+
+export interface LoginFormValues {
+	first_name?: string;
+	last_name?: string;
+	user_name?: string;
+	occupation?: string;
+	email: string;
+	password: string;
+	location?: string;
+	profile_image?: File | null;
+}
+
+export interface PoIFormValues {
+	title: string;
+	category: string;
+	description: string;
+	price?: number;
+	website?: string;
+	city?: string;
+	post_code?: string;
+	province: string;
+	country?: string;
+	phoneNumber?: string;
+	address?: string;
+	selectedOption: string;
+	longitude?: number;
+	latitude?: number;
+	userId: string;
+}
+
+export interface UserData {
+	user_name: string;
+	profile_image?: string;
+	first_name: string;
+	last_name: string;
+	occupation: string;
+	email: string;
+	location: string;
+}


### PR DESCRIPTION
- Added mobile styles to Profile page
    - I wanted to apply the sx={{textAlign: {xs: "center", sm: "left"}}} property to the whole list, but it doesn't apply so I had to apply it to each individual ListItemText component, which looks messy 
    - Any ideas for how to make it so it doesn't have to be so repetitive would be greatly appreciated
- Moved all frontend interface declarations to /types/interfaces.ts file. 
    - Wasn't sure about moving Prop type declarations as well - I like them to be in the same component that they are used in, but have never been certain if that's a best practice or not!
- Moved the "city" and "setCity" state declarations to the CitySearchForm (originally were declared in Landing.tsx parent component), as the state is only used in the form as far as I can tell

Goes without saying that this will cause some merge conflicts with other PRs due to moving the interfaces - happy to wait until other PRs are merged, clear up merge conflicts, then resubmit. Just wanted to get eyes/opinions on it now :) 